### PR TITLE
Close brand link before navigation

### DIFF
--- a/partials/header.html
+++ b/partials/header.html
@@ -6,6 +6,7 @@
         <!-- Logo/Brand -->
         <a href="/" class="brand" aria-label="Shine Design Home">
           <img src="/assets/images/logo.webp" alt="Shine Design Logo">
+        </a>
 
         <!-- Desktop Navigation -->
         <nav class="nav-links" aria-label="Primary">


### PR DESCRIPTION
## Summary
- Stop header navigation being wrapped inside the brand link by closing the anchor after the logo image.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c52874a07c832ba93c8642ce337f91